### PR TITLE
feat: thiserror, tracingクレートの導入

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
+ "tracing-error",
+ "tracing-subscriber",
  "tracing_spanned",
 ]
 
@@ -472,6 +474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "object"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +497,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -844,6 +862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -857,14 +876,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "nu-ansi-term",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -895,6 +928,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +950,28 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,8 +248,11 @@ dependencies = [
  "clap",
  "dotenvy",
  "rustls-pemfile",
+ "thiserror",
  "tokio",
  "tokio-rustls",
+ "tracing",
+ "tracing_spanned",
 ]
 
 [[package]]
@@ -674,6 +677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +746,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tokio"
 version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +813,67 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing_spanned"
+version = "0.1.0"
+source = "git+https://github.com/pulsuite/tracing_spanned?rev=6fed6097d13d117e4d35120f56450b156c33b77e#6fed6097d13d117e4d35120f56450b156c33b77e"
+dependencies = [
+ "tracing",
+ "tracing-error",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "tracing_spanned"
 version = "0.1.0"
-source = "git+https://github.com/pulsuite/tracing_spanned?rev=6fed6097d13d117e4d35120f56450b156c33b77e#6fed6097d13d117e4d35120f56450b156c33b77e"
+source = "git+https://github.com/comnipl/tracing_spanned?rev=6fed6097d13d117e4d35120f56450b156c33b77e#6fed6097d13d117e4d35120f56450b156c33b77e"
 dependencies = [
  "tracing",
  "tracing-error",

--- a/clocking-server/Cargo.toml
+++ b/clocking-server/Cargo.toml
@@ -7,5 +7,8 @@ edition = "2021"
 clap = { version = "4.5.15", features = ["derive", "env"] }
 dotenvy = "0.15.7"
 rustls-pemfile = "2.1.3"
+thiserror = "1.0.64"
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.26.0"
+tracing = "0.1.40"
+tracing_spanned = { git = "https://github.com/pulsuite/tracing_spanned", rev = "6fed6097d13d117e4d35120f56450b156c33b77e" }

--- a/clocking-server/Cargo.toml
+++ b/clocking-server/Cargo.toml
@@ -11,4 +11,6 @@ thiserror = "1.0.64"
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.26.0"
 tracing = "0.1.40"
+tracing-error = "0.2.0"
+tracing-subscriber = "0.3.18"
 tracing_spanned = { git = "https://github.com/pulsuite/tracing_spanned", rev = "6fed6097d13d117e4d35120f56450b156c33b77e" }

--- a/clocking-server/Cargo.toml
+++ b/clocking-server/Cargo.toml
@@ -13,4 +13,4 @@ tokio-rustls = "0.26.0"
 tracing = "0.1.40"
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
-tracing_spanned = { git = "https://github.com/pulsuite/tracing_spanned", rev = "6fed6097d13d117e4d35120f56450b156c33b77e" }
+tracing_spanned = { git = "https://github.com/comnipl/tracing_spanned", rev = "6fed6097d13d117e4d35120f56450b156c33b77e" }

--- a/clocking-server/src/cert.rs
+++ b/clocking-server/src/cert.rs
@@ -1,0 +1,45 @@
+use crate::err::ClockerError;
+
+use std::fs::File;
+use std::io::BufReader;
+use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tracing::instrument;
+use tracing_spanned::SpanErr;
+
+#[instrument(skip_all, name = "read_cert_file", level = "trace")]
+pub fn read_cert_file(
+    cert_path: String,
+) -> Result<Vec<CertificateDer<'static>>, SpanErr<ClockerError>> {
+    let mut cert_file = match File::open(cert_path) {
+        Ok(c) => c,
+        Err(e) => return Err(ClockerError::UnexpectedIO(e).into()),
+    };
+
+    let cert = match rustls_pemfile::certs(&mut BufReader::new(&mut cert_file))
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(c) => c,
+        Err(e) => return Err(ClockerError::UnexpectedIO(e).into()),
+    };
+
+    Ok(cert)
+}
+
+#[instrument(skip_all, name = "read_private_key_file", level = "trace")]
+pub fn read_private_key_file(
+    private_key_path: String,
+) -> Result<PrivateKeyDer<'static>, SpanErr<ClockerError>> {
+    let mut private_key_file = match File::open(private_key_path) {
+        Ok(c) => c,
+        Err(e) => return Err(ClockerError::UnexpectedIO(e).into()),
+    };
+
+    let private_key = match rustls_pemfile::private_key(&mut BufReader::new(&mut private_key_file))
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => return Err(ClockerError::PrivateKeyPEMSectionNotFound.into()),
+        Err(e) => return Err(ClockerError::UnexpectedIO(e).into()),
+    };
+
+    Ok(private_key)
+}

--- a/clocking-server/src/cert.rs
+++ b/clocking-server/src/cert.rs
@@ -10,11 +10,11 @@ use tracing_spanned::SpanErr;
 pub fn read_cert_file(
     cert_path: String,
 ) -> Result<Vec<CertificateDer<'static>>, SpanErr<ClockerError>> {
-    let mut cert_file = File::open(cert_path).map_err(ClockerError::UnexpectedIO)?;
+    let mut cert_file = File::open(cert_path).map_err(ClockerError::OpenFile)?;
 
     let cert = rustls_pemfile::certs(&mut BufReader::new(&mut cert_file))
         .collect::<Result<Vec<_>, _>>()
-        .map_err(ClockerError::UnexpectedIO)?;
+        .map_err(ClockerError::ReadFile)?;
 
     Ok(cert)
 }
@@ -23,11 +23,11 @@ pub fn read_cert_file(
 pub fn read_private_key_file(
     private_key_path: String,
 ) -> Result<PrivateKeyDer<'static>, SpanErr<ClockerError>> {
-    let mut private_key_file = File::open(private_key_path).map_err(ClockerError::UnexpectedIO)?;
+    let mut private_key_file = File::open(private_key_path).map_err(ClockerError::OpenFile)?;
 
     let private_key = rustls_pemfile::private_key(&mut BufReader::new(&mut private_key_file))
-        .map_err(ClockerError::UnexpectedIO)?
-        .ok_or(ClockerError::PrivateKeyPEMSectionNotFound)?;
+        .map_err(ClockerError::ReadFile)?
+        .ok_or(ClockerError::ReadPrivateKeyPEMSection)?;
 
     Ok(private_key)
 }

--- a/clocking-server/src/cert.rs
+++ b/clocking-server/src/cert.rs
@@ -10,11 +10,11 @@ use tracing_spanned::SpanErr;
 pub fn read_cert_file(
     cert_path: String,
 ) -> Result<Vec<CertificateDer<'static>>, SpanErr<ClockerError>> {
-    let mut cert_file = File::open(cert_path).map_err(ClockerError::OpenFile)?;
+    let mut cert_file = File::open(cert_path).map_err(ClockerError::LoadCertFile)?;
 
     let cert = rustls_pemfile::certs(&mut BufReader::new(&mut cert_file))
         .collect::<Result<Vec<_>, _>>()
-        .map_err(ClockerError::ReadFile)?;
+        .map_err(ClockerError::LoadCertFile)?;
 
     Ok(cert)
 }
@@ -23,10 +23,11 @@ pub fn read_cert_file(
 pub fn read_private_key_file(
     private_key_path: String,
 ) -> Result<PrivateKeyDer<'static>, SpanErr<ClockerError>> {
-    let mut private_key_file = File::open(private_key_path).map_err(ClockerError::OpenFile)?;
+    let mut private_key_file =
+        File::open(private_key_path).map_err(ClockerError::LoadPrivateKeyFile)?;
 
     let private_key = rustls_pemfile::private_key(&mut BufReader::new(&mut private_key_file))
-        .map_err(ClockerError::ReadFile)?
+        .map_err(ClockerError::LoadPrivateKeyFile)?
         .ok_or(ClockerError::ReadPrivateKeyPEMSection)?;
 
     Ok(private_key)

--- a/clocking-server/src/err.rs
+++ b/clocking-server/src/err.rs
@@ -1,6 +1,7 @@
-use std::io;
+use std::{io, string::FromUtf8Error};
 
 use thiserror::Error;
+use tokio_rustls::rustls;
 
 #[derive(Error, Debug)]
 pub enum ClockerError {
@@ -8,8 +9,12 @@ pub enum ClockerError {
     CreateTCPListener(u16),
     #[error("accept new connection")]
     AcceptNewConnection,
+    #[error("private key pem section not found")]
+    PrivateKeyPEMSectionNotFound,
     #[error("unexpected io error. {0}")]
     UnexpectedIO(io::Error),
-    #[error("unexpected error")]
-    Unexpected,
+    #[error("unexpected rust ls error. {0}")]
+    UnexpectedRustls(rustls::Error),
+    #[error("unexpected convert error. {0}")]
+    UnexpectedFromUtf(FromUtf8Error),
 }

--- a/clocking-server/src/err.rs
+++ b/clocking-server/src/err.rs
@@ -8,10 +8,10 @@ use tracing_subscriber::util::TryInitError;
 pub enum ClockerError {
     #[error("initialize tracing subscriber error. {0}")]
     InitializeTracingSubscriber(TryInitError),
-    #[error("create tcp listener error. port: {0}")]
-    CreateTCPListener(u16),
+    #[error("create tcp listener error. err: {0}, port: {1}")]
+    CreateTCPListener(io::Error, u16),
     #[error("accept new connection")]
-    AcceptNewConnection,
+    AcceptNewConnection(io::Error),
     #[error("private key pem section not found")]
     PrivateKeyPEMSectionNotFound,
     #[error("unexpected io error. {0}")]

--- a/clocking-server/src/err.rs
+++ b/clocking-server/src/err.rs
@@ -5,6 +5,8 @@ use tokio_rustls::rustls;
 
 #[derive(Error, Debug)]
 pub enum ClockerError {
+    #[error("initialize tracing subscriber error")]
+    InitializeTracingSubscriber,
     #[error("create tcp listener error. port: {0}")]
     CreateTCPListener(u16),
     #[error("accept new connection")]

--- a/clocking-server/src/err.rs
+++ b/clocking-server/src/err.rs
@@ -1,0 +1,15 @@
+use std::io;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ClockerError {
+    #[error("create tcp listener error. port: {0}")]
+    CreateTCPListener(u16),
+    #[error("accept new connection")]
+    AcceptNewConnection,
+    #[error("unexpected io error. {0}")]
+    UnexpectedIO(io::Error),
+    #[error("unexpected error")]
+    Unexpected,
+}

--- a/clocking-server/src/err.rs
+++ b/clocking-server/src/err.rs
@@ -2,11 +2,12 @@ use std::{io, string::FromUtf8Error};
 
 use thiserror::Error;
 use tokio_rustls::rustls;
+use tracing_subscriber::util::TryInitError;
 
 #[derive(Error, Debug)]
 pub enum ClockerError {
-    #[error("initialize tracing subscriber error")]
-    InitializeTracingSubscriber,
+    #[error("initialize tracing subscriber error. {0}")]
+    InitializeTracingSubscriber(TryInitError),
     #[error("create tcp listener error. port: {0}")]
     CreateTCPListener(u16),
     #[error("accept new connection")]

--- a/clocking-server/src/err.rs
+++ b/clocking-server/src/err.rs
@@ -6,24 +6,24 @@ use tracing_subscriber::util::TryInitError;
 
 #[derive(Error, Debug)]
 pub enum ClockerError {
-    #[error("initialize tracing subscriber error. {0}")]
+    #[error("initialize tracing subscriber error: {0}")]
     InitializeTracingSubscriber(TryInitError),
-    #[error("create tcp listener error. err: {0}, port: {1}")]
+    #[error("create tcp listener error: {0}, port: {1}")]
     CreateTCPListener(io::Error, u16),
-    #[error("accept new connection")]
+    #[error("failed to accept new connection")]
     AcceptNewConnection(io::Error),
-    #[error("accept new stream")]
+    #[error("failed to accept new stream")]
     AcceptNewStream(io::Error),
     #[error("private key pem section not found")]
     ReadPrivateKeyPEMSection,
-    #[error("unexpected rust ls error. {0}")]
+    #[error("build tls server error: {0}")]
     BuildServer(rustls::Error),
-    #[error("failed to open file. {0}")]
-    OpenFile(io::Error),
-    #[error("failed to read file. {0}")]
-    ReadFile(io::Error),
-    #[error("failed to read buffer. {0}")]
+    #[error("failed to load cert file: {0}")]
+    LoadCertFile(io::Error),
+    #[error("failed to load private key file: {0}")]
+    LoadPrivateKeyFile(io::Error),
+    #[error("failed to read buffer: {0}")]
     ReadBuffer(io::Error),
-    #[error("failed to convert string. {0}")]
-    ConvertBuffer(FromUtf8Error),
+    #[error("failed to convert buffer to string: {0}")]
+    ConvertBufferToString(FromUtf8Error),
 }

--- a/clocking-server/src/err.rs
+++ b/clocking-server/src/err.rs
@@ -12,12 +12,18 @@ pub enum ClockerError {
     CreateTCPListener(io::Error, u16),
     #[error("accept new connection")]
     AcceptNewConnection(io::Error),
+    #[error("accept new stream")]
+    AcceptNewStream(io::Error),
     #[error("private key pem section not found")]
-    PrivateKeyPEMSectionNotFound,
-    #[error("unexpected io error. {0}")]
-    UnexpectedIO(io::Error),
+    ReadPrivateKeyPEMSection,
     #[error("unexpected rust ls error. {0}")]
-    UnexpectedRustls(rustls::Error),
-    #[error("unexpected convert error. {0}")]
-    UnexpectedFromUtf(FromUtf8Error),
+    BuildServer(rustls::Error),
+    #[error("failed to open file. {0}")]
+    OpenFile(io::Error),
+    #[error("failed to read file. {0}")]
+    ReadFile(io::Error),
+    #[error("failed to read buffer. {0}")]
+    ReadBuffer(io::Error),
+    #[error("failed to convert string. {0}")]
+    ConvertBuffer(FromUtf8Error),
 }

--- a/clocking-server/src/main.rs
+++ b/clocking-server/src/main.rs
@@ -29,7 +29,7 @@ struct Args {
 #[tokio::main]
 #[instrument(skip_all, name = "main", level = "trace")]
 async fn main() -> Result<(), SpanErr<ClockerError>> {
-    tracing_subscriber::Registry::default()
+    let Ok(_) = tracing_subscriber::Registry::default()
         .with(
             tracing_subscriber::fmt::layer()
                 .with_target(false)
@@ -37,7 +37,9 @@ async fn main() -> Result<(), SpanErr<ClockerError>> {
         )
         .with(ErrorLayer::default())
         .try_init()
-        .expect("failed to initialize subscriber");
+    else {
+        return Err(ClockerError::InitializeTracingSubscriber.into());
+    };
 
     let _ = dotenv();
 

--- a/clocking-server/src/main.rs
+++ b/clocking-server/src/main.rs
@@ -82,7 +82,7 @@ fn get_tls_acceptor(
     let config = rustls::ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(cert, private_key)
-        .map_err(ClockerError::UnexpectedRustls)?;
+        .map_err(ClockerError::BuildServer)?;
 
     Ok(TlsAcceptor::from(Arc::new(config)))
 }
@@ -92,15 +92,15 @@ async fn process(acceptor: TlsAcceptor, stream: TcpStream) -> Result<(), SpanErr
     let mut tls_stream = acceptor
         .accept(stream)
         .await
-        .map_err(ClockerError::UnexpectedIO)?;
+        .map_err(ClockerError::AcceptNewStream)?;
 
     let mut buf = Vec::with_capacity(4096);
     let _ = tls_stream
         .read_buf(&mut buf)
         .await
-        .map_err(ClockerError::UnexpectedIO)?;
+        .map_err(ClockerError::ReadBuffer)?;
 
-    let msg = String::from_utf8(buf).map_err(ClockerError::UnexpectedFromUtf)?;
+    let msg = String::from_utf8(buf).map_err(ClockerError::ConvertBuffer)?;
     let result = tls_stream.write(msg.as_bytes()).await;
 
     println!(

--- a/clocking-server/src/main.rs
+++ b/clocking-server/src/main.rs
@@ -100,7 +100,7 @@ async fn process(acceptor: TlsAcceptor, stream: TcpStream) -> Result<(), SpanErr
         .await
         .map_err(ClockerError::ReadBuffer)?;
 
-    let msg = String::from_utf8(buf).map_err(ClockerError::ConvertBuffer)?;
+    let msg = String::from_utf8(buf).map_err(ClockerError::ConvertBufferToString)?;
     let result = tls_stream.write(msg.as_bytes()).await;
 
     println!(


### PR DESCRIPTION
* https://github.com/SuteraVR/VanillaClocker/issues/4 の内容のthiserror, tracingクレートを導入する部分まで対応
* tracingの初期化、関数のinstrument化を対応
* `Box<dyn Error>` としていた箇所を全て共通のエラーとして処理出来るように発生したエラーをwrap